### PR TITLE
feat: subshell processing for hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,7 @@ jobs:
       # Runs a single command using the runners shell
       - name: Run the tests
         run: |
-          just download-shunit
-          just test
+          just test-in-docker
 
       - name: Set the default docker tag, depending on branch name
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,7 @@ jobs:
       # Runs a single command using the runners shell
       - name: Run the tests
         run: |
-          just download-shunit
-          just test
+          just test-in-docker
 
       - name: Log in to the GitHub Container Registry
         uses: docker/login-action@v3

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,26 @@
+FROM debian:trixie-slim AS test
+
+ARG TEST_USER=testuser
+ARG TEST_USER_HOME=/home/testuser
+
+ENV TEST_USER=$TEST_USER
+ENV TEST_USER_HOME=$TEST_USER_HOME
+
+COPY --from=ghcr.io/casey/just:latest /just /usr/local/bin/
+
+RUN command -v curl >/dev/null 2>&1 || (apt-get update && apt-get install -y curl git tree)
+
+RUN useradd \
+    --create-home \
+    --home-dir $TEST_USER_HOME \
+    --uid 1000 \
+    --shell /bin/sh \
+    $TEST_USER
+
+WORKDIR /staging
+
+COPY --parents caifs/ tests/ Justfile /staging
+
+RUN ls -lh
+RUN just download-shunit
+RUN just test

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -19,7 +19,10 @@ RUN useradd \
 
 WORKDIR /staging
 
-COPY --parents caifs/ tests/ Justfile /staging
+#COPY --parents caifs/ tests/ Justfile /staging
+COPY ./caifs  /staging/caifs
+COPY ./tests /staging/tests
+COPY Justfile .
 
 RUN ls -lh
 RUN just download-shunit

--- a/Justfile
+++ b/Justfile
@@ -21,6 +21,14 @@ download-shunit:
     mv shunit2-${SHUNIT2_VERSION} shunit2
     rm -rf shunit2-${SHUNIT2_VERSION}
 
+[script]
+test-in-docker:
+    docker build \
+    --progress=plain \
+    --no-cache \
+     -f Dockerfile.test \
+     .
+
 # Run integration and unit tests
 [script]
 test:

--- a/README.md
+++ b/README.md
@@ -287,7 +287,9 @@ caifs add git@caifs-common fzf curl custom@my-dotfiles
 Configuring `sudo` is generally recommended for ease of use, especially when working with docker containers. The default
 in WSL2 is something akin to `echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers`
 
-This is fine for a dedicated local dev machine, but if you working with containers then you might want to restrict that.
+This is fine for a dedicated local dev machine, but if you working with containers then you might want to restrict sudo
+or better, yet make use of the `CAIFS_LINK_ROOT` and `CAIFS_USER` variables to install within another users home
+directory, or, provide the correct permissions.
 
 Depending on your distro of choice, CAIFS requires the following for `sudo` access
 
@@ -390,7 +392,7 @@ to the default `$HOME` destination for links.
 You can specify this with the `-r|--link-root` flags for the `add|rm` commands or use the `$CAIFS_LINK_ROOT` environment
 variable
 
-In a typical docker builds, or perhaps escalated automation scenarios where you are running as root, but want the
+In typical docker builds, or perhaps escalated automation scenarios where you are running as root, but want the
 configuration to be placed into another users home directory.
 
 ``` Dockerfile
@@ -404,7 +406,6 @@ RUN useradd \
     --shell /bin/sh \
     appuser
 
-
 # Copy over a collection, or perhaps curl one on from github
 COPY my-docker-collection /usr/local/share/my-docker-collection
 
@@ -413,6 +414,7 @@ COPY my-docker-collection /usr/local/share/my-docker-collection
 RUN curl -sL https://github.com/caifs-org/caifs/install.sh | sh && \
     caifs add uv git pre-commit ruff \
       --link-root /app \
+      --user appuser:appuser \
       -d /usr/local/share/my-docker-collection
 ```
 
@@ -432,12 +434,13 @@ of configuration that should only be linked in a particular environment, provide
 
 ### Command Options
 
-| Option               | Env Variable        | Description                                  |
-|----------------------|---------------------|----------------------------------------------|
-| `--verbose`, `-v`    | `CAIFS_VERBOSE=0`   | Show debug logs                              |
-| `--force`, `-f`      | `CAIFS_RUN_FORCE=0` | Remove existing links/files on conflict      |
-| `--links`, `-l`      | `CAIFS_RUN_LINKS=0` | Run only links, disable hooks                |
-| `--hooks`, `-h`      | `CAIFS_RUN_HOOKS=0` | Run only hooks, disable links                |
-| `--dry-run`, `-n`    | `CAIFS_DRY_RUN=0`   | Show what would run without making changes   |
-| `--collection`, `-c` | -                   | Constrain the targets to a single collection |
-|                      |                     |                                              |
+| Option               | Env Variable        | Description                                             |
+|----------------------|---------------------|---------------------------------------------------------|
+| `--verbose`, `-v`    | `CAIFS_VERBOSE=0`   | Show debug logs                                         |
+| `--force`, `-f`      | `CAIFS_RUN_FORCE=0` | Remove existing links/files on conflict                 |
+| `--links`, `-l`      | `CAIFS_RUN_LINKS=0` | Run only links, disable hooks                           |
+| `--hooks`, `-h`      | `CAIFS_RUN_HOOKS=0` | Run only hooks, disable links                           |
+| `--dry-run`, `-n`    | `CAIFS_DRY_RUN=0`   | Show what would run without making changes              |
+| `--collection`, `-c` | -                   | Constrain the targets to a single collection            |
+| `--user`, `-u`       | `CAIFS_USER`        | Apply the user permissions to links and instlaled files |
+|                      |                     |                                                         |

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ caifs add git@caifs-common fzf curl custom@my-dotfiles
 |                           |                                  | Set to `1` to specify not in container, regardless of if in a container or not |
 | `CAIFS_IN_WSL`            | unset                            | Set to `0` to set WSL config to run. Set to `1` to force to run                |
 | `CAIFS_LOCAL_COLLECTIONS` | ~/.local/share/caifs-collections | A central store for collections that is automatically checked.                 |
+| `CAIFS_USER`              | `$USER`                          | Override the user that the links will be owned by                              |
 |                           |                                  |                                                                                |
 
 ## Advanced Configuration

--- a/caifs/config/bin/caifs
+++ b/caifs/config/bin/caifs
@@ -66,6 +66,7 @@ Add Command options:
   -f, --force             Overwrite existing files/links
   -n, --dry-run           Don't do any linking or run hooks, just print the action
   -r, --link-root <path>  Set an alternative to $HOME as the link destination
+  -u, --user              Set an alternative to the $USER as the the link or install owner
 
 Remove Command options:
   -d, --directory <path>  Collection directory (can be specified multiple times)
@@ -90,6 +91,7 @@ Environment variables:
   CAIFS_RUN_FORCE         Set to 0 to force overwrite existing files/links
   CAIFS_RUN_LINKS         Set to 1 to skip symlinking
   CAIFS_RUN_HOOKS         Set to 1 to skip hooks
+  CAIFS_USER              User to apply ownership of links and installed files (default: $USER)
 
 Examples:
   caifs add git                       Run git target from current directory
@@ -141,7 +143,7 @@ main() {
     case "$SUBCOMMAND" in
         add)
             # Parse 'run' specific options
-            SUB_TEMP=$(getopt -o r:nflhd:c: -l link-root:,dry-run,force,links,hooks,directory:,collection: -n "run" -- "$@")
+            SUB_TEMP=$(getopt -o r:nflhd:c:u: -l link-root:,dry-run,force,links,hooks,directory:,collection:,user: -n "run" -- "$@")
             # shellcheck disable=SC2181
             if [ $? -ne 0 ]; then exit 1; fi
             eval set -- "$SUB_TEMP"
@@ -164,6 +166,7 @@ main() {
                     -r|--link-root) set_link_root "$(realpath "$2")"; shift 2;;
                     -c|--collection) set_collection_constraint "$2"; shift 2;;
                     -f|--force) set_force 0; shift ;;
+                    -u|--user) set_run_user "$2"; shift 2;;
                     --) shift; break ;;
                     *) break ;;
                 esac

--- a/caifs/config/lib/caifslib.sh
+++ b/caifs/config/lib/caifslib.sh
@@ -780,7 +780,7 @@ uv_install() {
         log_debug "Found ${PACKAGE}_VERSION=$PACKAGE_VERSION"
         PACKAGE="$PACKAGE==$PACKAGE_VERSION"
     fi
-    uv tool install --upgrade "$PACKAGE $*"
+    uv tool install --upgrade "$PACKAGE" "$@"
 }
 
 # Removes a package via a uv tool install

--- a/caifs/config/lib/caifslib.sh
+++ b/caifs/config/lib/caifslib.sh
@@ -680,6 +680,7 @@ create_link() {
             mkdir_cmd="rootdo $mkdir_cmd"
         fi
         dry_or_exec "$mkdir_cmd"
+        ensure_permissions "$basedir" "$require_escalation"
     fi
 
     link_cmd="ln -s $source_file $dest_link"
@@ -691,7 +692,7 @@ create_link() {
     log_info "Creating Link $source_file -> $dest_link"
     dry_or_exec "$link_cmd"
 
-    change_owner "$dest_link" "$require_escalation"
+    ensure_permissions "$dest_link" "$require_escalation"
 }
 
 # $1 - line to conditionally add
@@ -937,9 +938,9 @@ ensure_permissions() {
 
     if [ -n "${RUN_USER}" ]; then
         if [ "$needs_root" -eq 0 ]; then
-            dry_or_exec rootdo chown -hR "${RUN_USER}" "$1"
+            dry_or_exec rootdo chown -R "${RUN_USER}" "$1"
         else
-            dry_or_exec chown -hR "${RUN_USER}" "$1"
+            dry_or_exec chown -R "${RUN_USER}" "$1"
         fi
     fi
 }

--- a/caifs/config/lib/caifslib.sh
+++ b/caifs/config/lib/caifslib.sh
@@ -61,6 +61,10 @@ COLLECTION_CONSTRAINT=""
 # this can be overridden
 export LINK_ROOT="${CAIFS_LINK_ROOT:-$HOME}"
 
+# The user that links should be owned by, which is useful in root situations like docker where installs are typically
+# performed by the root user, but can be owned by the
+export RUN_USER="${CAIFS_USER:=$USER}"
+
 # Source the OS type and export the most useful for being available in executed scripts
 export OS_TYPE=
 OS_TYPE="$(uname -s)"
@@ -113,6 +117,14 @@ get_link_root() {
 
 set_force() {
     RUN_FORCE=${1}
+}
+
+set_run_user() {
+    RUN_USER=${1}
+}
+
+get_run_user() {
+    echo "$RUN_USER"
 }
 
 # Enables (0) or disables (1) the debugging logs
@@ -455,8 +467,9 @@ run_hook() {
         log_debug "Running ${hook_type}-hook for target '$target' in collection $collection_path"
         # Run within a subshell, this has the benefit of any sourced script functions and variables
         # do not pollute subsequent targets on the same run
+        export CAIFS_TARGET="$target"
         (
-            export CAIFS_TARGET="$target"
+
             TMP_DIR=$(mktemp -d)
             cd "${TMP_DIR}" || exit
 
@@ -470,6 +483,8 @@ run_hook() {
             cd - || exit
             rm -rf "${TMP_DIR}"
         )
+        unset CAIFS_TARGET
+
     else
         log_debug "No ${hook_type}-hook found for target '$target'. Ignoring"
     fi
@@ -675,6 +690,8 @@ create_link() {
 
     log_info "Creating Link $source_file -> $dest_link"
     dry_or_exec "$link_cmd"
+
+    change_owner "$dest_link" "$require_escalation"
 }
 
 # $1 - line to conditionally add
@@ -714,9 +731,18 @@ has_or_exit() {
 check_and_exec_function() {
     func_name=$1
     if type "$func_name" > /dev/null 2>&1; then
+        log_debug "function name=$func_name exists and will be run"
         shift 1
         eval "$func_name $*"
+        rc="$?"
+        if [ "$rc" -ne 0 ]; then
+            log_info "$func_name exited with non-zero exit code, rc=$rc"
+            exit "$rc"
+        fi
+    else
+        log_debug "skipping function name=$func_name as it does not exist"
     fi
+
 }
 
 # Looks for a version environment variable for a given name
@@ -736,7 +762,8 @@ version_from_env() {
 # This function helps during container builds, as usually the container runs as root and sudo isn't installed.
 # This negates the need to add sudo, but must be run as root now
 rootdo() {
-    # If this is not run as an elevated user, then attempt to run the entire script again as sudo
+    # If this is not run as an elevated user, then attempt to run the entire script again as sudo, or failing that
+    # execute the command as root, on behalf of the user. Which may require an interactive password prompt
     if [ "$(id -u)" -ne 0 ]; then
         if has sudo ; then
             sudo "$@"
@@ -762,6 +789,26 @@ yay_install() {
 yay_uninstall() {
     has_or_exit yay
     yay -Rns --noconfirm "$@"
+}
+
+# Install packages via apt-get for debian and ubuntu
+# rudimentary checks are in place to determine if and update is required
+# $@ packages and options to install
+apt_install() {
+    has_or_exit apt-get
+
+    if ! ls -l /var/lib/apt/lists/; then
+        rootdo apt-get update
+    fi
+
+    rootdo apt-get install -y "$@"
+}
+
+# uninstall packages via apt-get for debian and ubuntu
+# $@packages and options to uninstall
+apt_uninstall() {
+    has_or_exit apt-get
+    rootdo apt-get uninstall -y "$@"
 }
 
 # This helper function can be used for installing tools via uv
@@ -882,9 +929,25 @@ fedora_cert_handler() {
     rhel_cert_handler "$@"
 }
 
+# Changes the permissions of a file or link according to the $RUN_USER variable, if set
+# $1: The file or directory
+# $2: root permissions required flag, default 1 false
+ensure_permissions() {
+    needs_root=${2:-1}
+
+    if [ -n "${RUN_USER}" ]; then
+        if [ "$needs_root" -eq 0 ]; then
+            dry_or_exec rootdo chown -hR "${RUN_USER}" "$1"
+        else
+            dry_or_exec chown -hR "${RUN_USER}" "$1"
+        fi
+    fi
+}
+
 # A utility that allows installing software from a hook script, with respect to the LINK_ROOT
 # It performs root escalation, if the current LINK_ROOT is anchored at /
 # Files will be copied recurisvely to the LINK_ROOT destination, so $1 path should be in required order
+# Note: Function respects the CAIFS_USER variable, so ownership will be applied to all files if set
 # $1: Path to install
 # $2: Optional extra directory, useful for the LINK_ROOT=$HOME use case. Defaults to .local
 caifs_install() {
@@ -894,13 +957,17 @@ caifs_install() {
     if is_root_config "$LINK_ROOT"; then
         log_debug "Link root appears to reference / - escalating privileges for copy"
         dry_or_exec rootdo cp -r "$1" "$LINK_ROOT/"
+        ensure_permissions "$LINK_ROOT" 1
     elif [ "$LINK_ROOT" = "$HOME" ]; then
         log_debug "Link root is the default \$HOME - copying to $LINK_ROOT/$link_root_home/"
         dry_or_exec cp -r "$1" "$LINK_ROOT/$link_root_home/"
+        ensure_permissions "$LINK_ROOT"
     else
-        # respect LINK_ROOT,but it appears to not need privileges
+        # respect LINK_ROOT, but it appears to not need privileges
         dry_or_exec cp -r "$1" "$LINK_ROOT/"
+        ensure_permissions "$LINK_ROOT"
     fi
+
 }
 
 # Generic install script for installing per OS_ID based on the above global

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -7,6 +7,9 @@ oneTimeSetUp() {
     if ! command -v caifs &>/dev/null; then
         PATH="$(dirname $0)/../caifs/config/bin/:$PATH"
     fi
+
+    TEST_USER=${TEST_USER:-$TEST_USER}
+    TEST_USER_HOME=${TEST_USER_HOME:-$TEST_USER_HOME}
 }
 
 oneTimeTearDown() {
@@ -245,6 +248,23 @@ test_wildcard_explicit_constraint() {
     assertTrue ".bashrc should be linked to root dir after add a link" "[ -L $CAIFS_LINK_ROOT/.bashrc ]"
     link=$(readlink "$CAIFS_LINK_ROOT/.bashrc")
     assertEquals "Only dummy_1 should be linked" "$COLLECTION_BASE_DIR/dummy_1/bash/config/.bashrc" "$link"
+}
+
+# Test that running as root, with the correct link-root and user flags will correctly change the ownership
+test_ownership_from_root() {
+    CAIFS_LOCAL_COLLECTIONS=$COLLECTION_BASE_DIR caifs add '*@dummy_1' --links --user $TEST_USER:$TEST_USER --link-root $TEST_USER_HOME
+
+    assertTrue ".gitconfig should be linked to root dir after add a link" "[ -L $TEST_USER_HOME/.gitconfig ]"
+    link=$(readlink "$TEST_USER_HOME/.gitconfig")
+
+    link_owner=$(stat -c '%U' "$TEST_USER_HOME/.gitconfig")
+
+    assertSame "owner of link should be $TEST_USER" "$link_owner" "$TEST_USER"
+
+    assertTrue "File should be writable by owner" "[ -w $TEST_USER_HOME/.gitconfig ]"
+
+    ls -lah $TEST_USER_HOME
+
 }
 
 . ./shunit2/shunit2

--- a/tests/unit.sh
+++ b/tests/unit.sh
@@ -414,6 +414,8 @@ EOF
 }
 
 
+# Need to figure out a nice way to test ownership without messing with the
+# Perhaps moving to a container build will solve this
 test_ownership_recursive() {
     :
 

--- a/tests/unit.sh
+++ b/tests/unit.sh
@@ -374,22 +374,24 @@ test_hooks_subshell() {
 
     cat << EOF > $TMPDIR/my-collection/target1/hooks/pre.sh
 generic() {
-  echo "$CAIFS_TARGET" > generic_marker0.txt
+  echo "\$CAIFS_TARGET" > generic_marker0.txt
   export GENERIC_VARIABLE=test
 
-  echo "DRY_RUN=$DRY_RUN"
-  export -p
+  echo "DRY_RUN=\$DRY_RUN"
+  echo "target=\$target"
 
-  echo "target=$target"
-
-  if [ -z "$CAIFS_TARGET" ]; then
-     echo "$CAIFS_TARGET does not exist"
+  cat generic_marker0.txt
+  if [ -z "\$CAIFS_TARGET" ]; then
+     echo "CAIFS_TARGET=\$CAIFS_TARGET does not exist"
+     exit 2
+  else
+     echo "CAIFS_TARGET=\$CAIFS_TARGET does EXIST!"
      exit 1
   fi
 }
 
 linux() {
-  echo "$CAIFS_TARGET" > linux_marker0.txt
+  echo "\$CAIFS_TARGET" > linux_marker0.txt
   export LINUX_VARIABLE=test
 }
 EOF
@@ -406,9 +408,19 @@ EOF
     type "generic" 2>/dev/null | grep -q 'function'
     is_function_rc=$?
     assertTrue "The variables \$GENERIC_VARIABLE and \$LINUX_VARIABLE should not be set after the run " "[ -z "$GENERIC_VARIABLE" ]"
-    assertSame "The function generic shouldn't exist after running hooks" "1" "$is_function_rc"
+    assertSame "The function generic shouldn't exist after running the hook" "1" "$is_function_rc"
 
-    assertTrue "The CAIFS_TARGET variable should be set after a run" "[ -z "$CAIFS_TARGET" ]"
+    assertTrue "The CAIFS_TARGET variable should not be set after a run" "[ -z "$CAIFS_TARGET" ]"
+}
+
+
+test_ownership_recursive() {
+    :
+
+}
+
+test_ownership_link() {
+    :
 }
 
 . ./shunit2/shunit2

--- a/tests/unit.sh
+++ b/tests/unit.sh
@@ -4,7 +4,8 @@
 . ./$(dirname $0)/../caifs/config/lib/caifslib.sh
 
 oneTimeSetUp() {
-    :
+    TEST_USER=${TEST_USER:-$TEST_USER}
+    TEST_USER_HOME=${TEST_USER_HOME:-$TEST_USER_HOME}
 }
 
 oneTimeTearDown() {


### PR DESCRIPTION
added processing of hooks in its own subshell 
added --user and CAIFS_USER flag to allow linked files and files installed via `caifs_install` to have custom ownership
changed the tests to run within a container, so custom users can be added 