### PR TITLE
fix: Update `find` to support BSD

### DIFF
--- a/caifs/config/lib/caifslib.sh
+++ b/caifs/config/lib/caifslib.sh
@@ -143,7 +143,12 @@ get_collection_constraint() {
 # returns a loopable string of files found within the supplied directory
 # $1: The directory to search
 files_in_dir() {
-    find "${1}" \( -type f -o -type l \) -printf "%P\n" 2>/dev/null
+    dir=$1
+    [ -d "$dir" ] || return 0
+    (
+        cd "$dir" || exit 0
+        find . \( -type f -o -type l \) -print 2>/dev/null | sed 's|^\./||'
+    )
 }
 
 # Splits a string at a desired character and returns the portion before the character


### PR DESCRIPTION
## What
-  Old: Used `find ... -printf "%P\n"`
-  New: Uses `cd "$dir"` and `find . ... -print | sed 's|^\./||'`

## Why

- -printf is a GNU find extension not available in BSD find, nor is it POSIX compliant
- The new approach achieves the same result using only POSIX-compatible commands: cd, find, and sed
- The behaviour is the same;
  - Relative path generation without the leading `/`
